### PR TITLE
Update GitHub Actions workflow and pin Terraform AWS provider major version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
-  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -30,6 +29,10 @@ jobs:
         run: |
           echo "::set-env name=PY_VERSION::"\
           "$(python -c "import platform;print(platform.python_version())")"
+      - name: Store installed Go version
+        run: |
+          echo "::set-env name=GO_VERSION::"\
+          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')"
       - name: Lookup go cache directory
         id: go-cache
         run: |
@@ -37,19 +40,26 @@ jobs:
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
+          # Note that the .terraform directory IS NOT included in the
+          # cache because we use the -upgrade=true option when we run
+          # terraform below.  That option pulls down the latest
+          # modules and providers no matter what, so there is no point
+          # in caching the .terraform directory.
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
             ${{ steps.go-cache.outputs.dir }}
-            ${{ env.TF_CACHE_DIR }}
           key: "lint-${{ runner.os }}-\
             py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+            lint-${{ runner.os }}-\
+            py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-
             lint-${{ runner.os }}-
       - name: Install Terraform
@@ -67,8 +77,9 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'..."; \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
   required_version = ">= 0.12"
+
+  # If you use any other providers you should also pin them to the
+  # major version currently being used.  This practice will help us
+  # avoid unwelcome surprises.
+  required_providers {
+    aws = "~> 2.0"
+  }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Updates the GitHub Actions workflow to agree with the changes made recently in cisagov/skeleton-tf-module#27
* Pins the Terraform AWS provider major version as was done in cisagov/skeleton-tf-module#28

## 💭 Motivation and Context

This repository [failed an APB build](https://github.com/cisagov/ansible-role-kali/runs/971786599), so I started investigating why.  The APB build failure was apparently just a sporadic failure to download something from the internet; I reran the build and it executed cleanly.  While looking at this repo, though, I noticed that it was not entirely up to date with the recent GH Actions and TF provider pinning changes we have been making.  I went ahead and took care of that in this PR.

I think we should strongly consider creating a `skeleton-ansible-role-with-tf` to use as the skeleton for Ansible roles that require a TF user to run through their molecule tests.  Right now all such Ansible role repos are free to do their own thing with respect to the TF code that sets up the test user, and i think it would help keep them all up to date if we standardized.  What say you, @dav3r, @felddy, @hillaryj, and @mcdonnnj?

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
