### PR TITLE
Add Burp Suite Pro to software installed by this Ansible role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,9 +88,7 @@ third_party_bucket_name: cisa-cool-third-party-production
 # The name of the S3 object corresponding to the Burp Suite Pro Linux
 # installer
 burp_suite_installer_object_name: burpsuite_pro_linux_v2020_11.sh
-# The name of the S3 object corresponding to the Burp Suite Pro
-# license
-burp_suite_license_object_name: burpsuite_pro.license
+# Prerequisites needed to install Burp Suite Pro
 burp_suite_installation_prerequisites:
   # The installer application requires this
   - libfreetype6

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,3 +81,17 @@ dns_profile_randomizer:
 
 # Group ownership for the tools that are installed directly to /tools
 group: root
+
+# The name of the AWS S3 bucket where third-party software is located
+third_party_bucket_name: cisa-cool-third-party-production
+# The name of the S3 object corresponding to the Burp Suite Pro Linux
+# installer
+burp_suite_installer_object_name: burpsuite_pro_linux_v2020_11.sh
+# The name of the S3 object corresponding to the Burp Suite Pro
+# license
+burp_suite_license_object_name: burpsuite_pro.license
+# The directory where Burp Suite Pro should be installed
+burp_suite_install_directory: /usr/local/BurpSuitePro
+# The directory where symlinks to the Burp Suite Pro executables
+# should be created
+burp_suite_symlinks_directory: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,11 @@ burp_suite_installer_object_name: burpsuite_pro_linux_v2020_11.sh
 # The name of the S3 object corresponding to the Burp Suite Pro
 # license
 burp_suite_license_object_name: burpsuite_pro.license
+burp_suite_installation_prerequisites:
+  # The installer application requires this
+  - libfreetype6
+  # This is required for the Ansible expect module
+  - python3-pexpect
 # The directory where Burp Suite Pro should be installed
 burp_suite_install_directory: /usr/local/BurpSuitePro
 # The directory where symlinks to the Burp Suite Pro executables

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -104,7 +104,7 @@ def test_directories(host, dir):
     assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')
 
 
-def test_file(host):
+def test_bsp_installed(host):
     """Test that Burp Suite Pro was installed."""
     dir_full_path = "/usr/local/BurpSuitePro"
     directory = host.file(dir_full_path)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -101,3 +101,13 @@ def test_directories(host, dir):
     assert directory.is_directory
     # Make sure that the directory is not empty
     assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')
+
+
+def test_file(host):
+    """Test that Burp Suite Pro was installed."""
+    dir_full_path = "/usr/local/BurpSuitePro"
+    directory = host.file(dir_full_path)
+    assert directory.exists
+    assert directory.is_directory
+    # Make sure that the directory is not empty
+    assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -7,17 +7,14 @@
 
 - name: Install Burp Suite Pro
   block:
-    - name: Grab Burp Suite Pro installer and license from S3
+    - name: Grab Burp Suite Pro installer from S3
       aws_s3:
         bucket: "{{ third_party_bucket_name }}"
-        object: "{{ item }}"
-        dest: /tmp/{{ item }}
+        object: "{{ burp_suite_installer_object_name }}"
+        dest: /tmp/{{ burp_suite_installer_object_name }}
         mode: get
       become: no
       delegate_to: localhost
-      loop:
-        - "{{ burp_suite_installer_object_name }}"
-        - "{{ burp_suite_license_object_name }}"
 
     - name: Copy the Burp Suite Pro installer
       copy:
@@ -67,46 +64,12 @@
         - install_command.rc != 2
       register: install_command
 
-    - name: License Burp Suite Pro
-      expect:
-        chdir: "{{ burp_suite_install_directory }}"
-        command: ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
-        responses:
-          # $ ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
-          # Burp Suite Professional Terms & Conditions of Supply
-          #
-          # <snip>
-          # License text
-          # </snip>
-          # Do you accept the license agreement? (y/n)
-          # y
-          # This version of Burp requires a license key. To continue, please paste your license key below.
-          # <license key>
-          # Burp will now attempt to contact the license server and activate your license. This will require Internet access.
-          # NOTE: license activations are monitored. If you perform too many activations, further activations for this license may be prevented.
-          # Enter preferred activation method (o=online activation; m=manual activation; r=re-enter license key)
-          # o
-          # Your license is successfully installed and activated.
-          "Do you accept the license agreement\\?": "y"
-          "To continue, please paste your license key below\\.": "{{ lookup('file', '/tmp/' + burp_suite_license_object_name) }}"
-          "Enter preferred activation method": o
-      # This failed_when clause is required because the licensing
-      # command returns a nonzero return code even when it succeeds.
-      failed_when:
-        - license_command.rc != 0
-        - license_command.rc != 13
-        - license_command.rc != 129
-      register: license_command
-
-    - name: Delete local copies of Burp Suite Pro installer and license
+    - name: Delete local copy of Burp Suite Pro installer
       file:
-        path: /tmp/{{ item }}
+        path: /tmp/{{ burp_suite_installer_object_name }}
         state: absent
       become: no
       delegate_to: localhost
-      loop:
-        - "{{ burp_suite_installer_object_name }}"
-        - "{{ burp_suite_license_object_name }}"
 
     - name: Delete remote copy of Burp Suite Pro installer
       file:

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -64,6 +64,7 @@
       failed_when:
         - install_command.rc != 0
         - install_command.rc != 1
+        - install_command.rc != 2
       register: install_command
 
     - name: License Burp Suite Pro

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -59,6 +59,12 @@
           "Where should Burp Suite Professional be installed\\?": "{{ burp_suite_install_directory }}"
           "Create symlinks\\?": "y"
           "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ burp_suite_symlinks_directory }}"
+      # This failed_when clause is required because the installer
+      # command returns a nonzero return code even when it succeeds.
+      failed_when:
+        - install_command.rc != 0
+        - install_command.rc != 1
+      register: install_command
 
     - name: License Burp Suite Pro
       expect:

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -94,6 +94,7 @@
       failed_when:
         - license_command.rc != 0
         - license_command.rc != 13
+        - license_command.rc != 129
       register: license_command
 
     - name: Delete local copies of Burp Suite Pro installer and license

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -25,7 +25,7 @@
         mode: 0700
         src: /tmp/{{ burp_suite_installer_object_name }}
 
-    - name: Install Burp Suite Pro installer prerequisites
+    - name: Install Burp Suite Pro installation prerequisites
       package:
         name:
           - libfreetype6

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -1,0 +1,111 @@
+---
+# Check if Burp Suite Pro is already installed
+- name: Check if Burp Suite Pro is already installed
+  stat:
+    path: "{{ burp_suite_install_directory }}"
+  register: burp_suite_directory
+
+- name: Install Burp Suite Pro
+  block:
+    - name: Grab Burp Suite Pro installer and license from S3
+      aws_s3:
+        bucket: "{{ third_party_bucket_name }}"
+        object: "{{ item }}"
+        dest: /tmp/{{ item }}
+        mode: get
+      become: no
+      delegate_to: localhost
+      loop:
+        - "{{ burp_suite_installer_object_name }}"
+        - "{{ burp_suite_license_object_name }}"
+
+    - name: Copy the Burp Suite Pro installer
+      copy:
+        dest: /tmp/{{ burp_suite_installer_object_name }}
+        mode: 0700
+        src: /tmp/{{ burp_suite_installer_object_name }}
+
+    - name: Install Burp Suite Pro installer prerequisites
+      package:
+        name:
+          - libfreetype6
+          # This is required to use the Ansible expect module below
+          - python3-pexpect
+
+    - name: Install Burp Suite Pro
+      expect:
+        command: /tmp/{{ burp_suite_installer_object_name }}
+        creates: "{{ burp_suite_install_directory }}"
+        responses:
+          # $ sudo ./burpsuite_pro_linux_v2020_11.sh
+          # Unpacking JRE ...
+          # Starting Installer ...
+          # This will install Burp Suite Professional on your computer.
+          # OK [o, Enter], Cancel [c]
+          #
+          # Click Next to continue, or Cancel to exit Setup.
+          # Select the folder where you would like Burp Suite Professional to be
+          # installed, then click Next.
+          # Where should Burp Suite Professional be installed?
+          # [/usr/local/BurpSuitePro]
+          #
+          # Create symlinks?
+          # Yes [y, Enter], No [n]
+          #
+          # Select the folder where you would like Burp Suite Professional to create symlinks, then click Next.
+          # [/usr/local/bin]
+          #
+          # Extracting files ...
+          # Setup has finished installing Burp Suite Professional on your computer.
+          # Finishing installation ...
+          "This will install Burp Suite Professional on your computer\\.": o
+          "Where should Burp Suite Professional be installed\\?": "{{ burp_suite_install_directory }}"
+          "Create symlinks\\?": "y"
+          "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ burp_suite_symlinks_directory }}"
+
+    - name: License Burp Suite Pro
+      expect:
+        chdir: "{{ burp_suite_install_directory }}"
+        command: ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+        responses:
+          # $ ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+          # Burp Suite Professional Terms & Conditions of Supply
+          #
+          # <snip>
+          # License text
+          # </snip>
+          # Do you accept the license agreement? (y/n)
+          # y
+          # This version of Burp requires a license key. To continue, please paste your license key below.
+          # <license key>
+          # Burp will now attempt to contact the license server and activate your license. This will require Internet access.
+          # NOTE: license activations are monitored. If you perform too many activations, further activations for this license may be prevented.
+          # Enter preferred activation method (o=online activation; m=manual activation; r=re-enter license key)
+          # o
+          # Your license is successfully installed and activated.
+          "Do you accept the license agreement\\?": "y"
+          "To continue, please paste your license key below\\.": "{{ lookup('file', '/tmp/' + burp_suite_license_object_name) }}"
+          "Enter preferred activation method": o
+      # This failed_when clause is required because the licensing
+      # command returns a nonzero return code even when it succeeds.
+      failed_when:
+        - license_command.rc != 0
+        - license_command.rc != 13
+      register: license_command
+
+    - name: Delete local copies of Burp Suite Pro installer and license
+      file:
+        path: /tmp/{{ item }}
+        state: absent
+      become: no
+      delegate_to: localhost
+      loop:
+        - "{{ burp_suite_installer_object_name }}"
+        - "{{ burp_suite_license_object_name }}"
+
+    - name: Delete remote copy of Burp Suite Pro installer
+      file:
+        path: /tmp/{{ burp_suite_installer_object_name }}
+        state: absent
+
+  when: not burp_suite_directory.stat.exists

--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -27,10 +27,7 @@
 
     - name: Install Burp Suite Pro installation prerequisites
       package:
-        name:
-          - libfreetype6
-          # This is required to use the Ansible expect module below
-          - python3-pexpect
+        name: "{{ burp_suite_installation_prerequisites }}"
 
     - name: Install Burp Suite Pro
       expect:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for kali
-
 - name: Load tasks file for tools installed via package manager
   include_tasks: package_install.yml
 
@@ -15,3 +13,6 @@
 
 - name: Load tasks file for dns-profile-randomizer
   include_tasks: dns_profile_randomizer.yml
+
+- name: Load tasks file for Burp Suite Pro
+  include_tasks: burp_suite_pro.yml

--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -1,0 +1,29 @@
+# Create the roles that allow read-only access to the particular S3
+# objects that are required by this Ansible role
+module "production_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images_production_thirdparty
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = module.user.user.name
+  role_name   = "ThirdPartyBucketRead-${module.user.user.name}"
+  role_tags   = var.tags
+  s3_bucket   = var.production_bucket_name
+  s3_objects  = var.production_objects
+}
+
+module "staging_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images_staging_thirdparty
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = module.user.user.name
+  role_name   = "ThirdPartyBucketRead-${module.user.user.name}"
+  role_tags   = var.tags
+  s3_bucket   = var.staging_bucket_name
+  s3_objects  = var.staging_objects
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,9 +4,19 @@ output "access_key" {
   sensitive   = true
 }
 
+output "production_bucket_policy" {
+  value       = module.production_bucket_access.policy
+  description = "The IAM policy that allows the CI user to read certain objects in the production third-party S3 bucket."
+}
+
 output "production_role" {
   value       = module.user.production_role
   description = "The IAM role that the CI user can assume to read SSM parameters in the production account."
+}
+
+output "staging_bucket_policy" {
+  value       = module.staging_bucket_access.policy
+  description = "The IAM policy that allows the CI user to read certain objects in the staging third-party S3 bucket."
 }
 
 output "staging_role" {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -28,6 +28,28 @@ provider "aws" {
   }
 }
 
+# The provider used to create roles that can read objects from the
+# production third-party S3 bucket
+provider "aws" {
+  alias  = "images_production_thirdparty"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.images_production.outputs.provisionthirdpartybucketreadroles_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
+# The provider used to create roles that can read objects from the
+# staging third-party S3 bucket
+provider "aws" {
+  alias  = "images_staging_thirdparty"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionthirdpartybucketreadroles_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
 # The provider used to create policies and roles that can read
 # parameters from AWS SSM Parameter Store in staging.
 provider "aws" {

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -15,3 +15,21 @@ module "user" {
 
   tags = var.tags
 }
+
+# Attach third-party S3 bucket read-only policy to the production
+# EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "thirdpartybucketread_production" {
+  provider = aws.images_production_provisionaccount
+
+  policy_arn = module.production_bucket_access.policy.arn
+  role       = module.user.production_role.name
+}
+
+# Attach third-party S3 bucket read-only policy to the staging
+# EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "thirdpartybucketread_staging" {
+  provider = aws.images_staging_provisionaccount
+
+  policy_arn = module.staging_bucket_access.policy.arn
+  role       = module.user.staging_role.name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,6 +10,36 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "production_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket where the production Burp Suite Pro intaller and license live."
+  default     = "cisa-cool-third-party-production"
+}
+
+variable "production_objects" {
+  type        = list(string)
+  description = "The Burp Suite Pro installer and license objects inside the production bucket."
+  default = [
+    "burpsuite_pro.license",
+    "burpsuite_pro_linux_v2020_11.sh",
+  ]
+}
+
+variable "staging_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket where the staging Burp Suite Pro intaller and license live."
+  default     = "cisa-cool-third-party-staging"
+}
+
+variable "staging_objects" {
+  type        = list(string)
+  description = "The Burp Suite Pro installer and license objects inside the staging bucket."
+  default = [
+    "burpsuite_pro.license",
+    "burpsuite_pro_linux_v2020_11.sh",
+  ]
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created"


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds Burp Suite Pro to the software installed by this Ansible role.

## 💭 Motivation and Context ##

Resolves #37.

## 🧪 Testing ##

All pre-commit hooks and molecule tests pass.  I also built a staging AMI with these changes and verified that it indeed has Burp Suite Pro installed.  I was able to use Burp Suite Pro after licensing it.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
