### PR TITLE
Increase the timeout for the installation of Burp Suite Pro

### DIFF
--- a/tasks/burp_suite_pro.yml
+++ b/tasks/burp_suite_pro.yml
@@ -56,6 +56,7 @@
           "Where should Burp Suite Professional be installed\\?": "{{ burp_suite_install_directory }}"
           "Create symlinks\\?": "y"
           "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ burp_suite_symlinks_directory }}"
+        timeout: 300
       # This failed_when clause is required because the installer
       # command returns a nonzero return code even when it succeeds.
       failed_when:


### PR DESCRIPTION
## 🗣 Description ##

This pull request increases the timeout for the installation of Burp Suite Pro.

## 💭 Motivation and Context ##

I noticed that sometimes the expect Ansible module was timing out while installing Burp Suite Pro.  This is because the default timeout for the expect Ansible module is thirty seconds, but the installation of Burp Suite Pro can sometimes take longer than this.  Installation should definitely be complete within five minutes.

## 🧪 Testing ##

All molecule tests and pre-commit hooks complete successfully.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
