### PR TITLE
Install Google Chrome instead of Chromium (for now)

### DIFF
--- a/tasks/aquatone.yml
+++ b/tasks/aquatone.yml
@@ -10,11 +10,20 @@
           # (Bullseye) and therefore Kali Linux, so we install Google
           # Chrome directly from a deb file below.  See #45 for
           # details.
+          #
+          # TODO: Revert this change when the chromium package again
+          # becomes available.  See this issue:
+          # https://github.com/cisagov/ansible-role-kali/issues/47
+          #
           # - chromium
           - unzip
     # Chromium is currently removed from Debian Testing (Bullseye) and
     # therefore Kali Linux, so we install Google Chrome directly from
     # a deb file below.  See #45 for details.
+    #
+    # TODO: Revert this change when the chromium package again becomes
+    # available.  See this issue:
+    # https://github.com/cisagov/ansible-role-kali/issues/47
     - name: Install Google Chrome
       block:
         # apt requires this package when installing a deb file

--- a/tasks/aquatone.yml
+++ b/tasks/aquatone.yml
@@ -1,15 +1,30 @@
 ---
-# tasks file for aquatone
-
-# This tool is installed a bit differently.  The release zip for it
+# Aquatone is installed a bit differently.  The release zip for it
 # contains pre-compiled Go code, which is what we want to install.
 - name: Install aquatone
   block:
     - name: Install dependencies for aquatone
       package:
         name:
-          - chromium
+          # Chromium is currently removed from Debian Testing
+          # (Bullseye) and therefore Kali Linux, so we install Google
+          # Chrome directly from a deb file below.  See #45 for
+          # details.
+          # - chromium
           - unzip
+    # Chromium is currently removed from Debian Testing (Bullseye) and
+    # therefore Kali Linux, so we install Google Chrome directly from
+    # a deb file below.  See #45 for details.
+    - name: Install Google Chrome
+      block:
+        # apt requires this package when installing a deb file
+        - name: Install xz-utils
+          package:
+            name:
+              - xz-utils
+        - name: Install Google Chrome
+          apt:
+            deb: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - name: Create a directory where aquatone will be installed manually
       file:
         group: "{{ group }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes this Ansible role so that it installs [Google Chrome](https://www.google.com/chrome/) instead of [Chromium](https://www.chromium.org/Home).  One of these browsers is required as a dependency of [Aquatone](https://github.com/michenriksen/aquatone), which this Ansible role installs.

## 💭 Motivation and Context ##

The `chromium` package has been removed from Debian Testing (currently Bullseye) and hence is not available on Kali Linux.  Aquatone can use Google Chrome instead of Chromium, so we install that for now instead of Chromium.  When the `chromium` package again becomes available we can revert these changes.

Resolves #45.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
